### PR TITLE
LUT-25859: Update the value retrieved for bookmarks in some generic attributes

### DIFF
--- a/src/java/fr/paris/lutece/plugins/notifygru/modules/appointment/provider/AppointmentProvider.java
+++ b/src/java/fr/paris/lutece/plugins/notifygru/modules/appointment/provider/AppointmentProvider.java
@@ -58,6 +58,8 @@ import fr.paris.lutece.plugins.genericattributes.business.Entry;
 import fr.paris.lutece.plugins.genericattributes.business.EntryFilter;
 import fr.paris.lutece.plugins.genericattributes.business.EntryHome;
 import fr.paris.lutece.plugins.genericattributes.business.Response;
+import fr.paris.lutece.plugins.genericattributes.service.entrytype.EntryTypeServiceManager;
+import fr.paris.lutece.plugins.genericattributes.service.entrytype.IEntryTypeService;
 import fr.paris.lutece.plugins.workflow.modules.comment.business.CommentValue;
 import fr.paris.lutece.plugins.workflow.modules.comment.service.CommentValueService;
 import fr.paris.lutece.plugins.workflow.modules.comment.service.ICommentValueService;
@@ -280,11 +282,17 @@ public class AppointmentProvider implements IProvider
         List<Response> listResponses = AppointmentResponseService.findListResponse( _appointment.getIdAppointment( ) );
         for ( Response response : listResponses )
         {
-            Entry entry = EntryHome.findByPrimaryKey( response.getEntry( ).getIdEntry( ) );
-            collectionNotifyMarkers
-                    .add( createMarkerValues( AppointmentNotifyGruConstants.MARK_ENTRY_BASE + entry.getIdEntry( ), response.getResponseValue( ) ) );
-        }
+            IEntryTypeService entryTypeService = EntryTypeServiceManager.getEntryTypeService( response.getEntry( ) );
+            // Retrieve the value of the Response, depending on the EntryType
+            String responseRecapValue = entryTypeService.getResponseValueForRecap( response.getEntry( ), null, response, LocaleService.getDefault( ) );
 
+            if ( responseRecapValue == null )
+            {
+                responseRecapValue = StringUtils.EMPTY;
+            }
+            collectionNotifyMarkers
+                    .add( createMarkerValues( AppointmentNotifyGruConstants.MARK_ENTRY_BASE + response.getEntry( ).getIdEntry( ), responseRecapValue ) );
+        }
         return collectionNotifyMarkers;
     }
 


### PR DESCRIPTION
Use the method `getResponseValueForRecap` specific to each EntryType, to make sure we retrieve the proper value in the bookmarks.

This is usefull for elements of type checkbox, radio button, or selection list, where the value we need is actually stored as the title and has a specific way to be retrieved:

- c.f. [AbstractEntryTypeChoice Class](https://github.com/lutece-platform/lutece-genattrs-plugin-genericattributes/blob/75a4f83500d56bcbafb92f035736cef37e955f7a/src/java/fr/paris/lutece/plugins/genericattributes/service/entrytype/AbstractEntryTypeChoice.java#L63)